### PR TITLE
💄 [UI]: メニュー画面のレイアウトをグリッド表示に改善

### DIFF
--- a/gomoku-game/src/components/elements/OptionSelector/OptionSelector.tsx
+++ b/gomoku-game/src/components/elements/OptionSelector/OptionSelector.tsx
@@ -12,6 +12,8 @@ type Props<T> = {
   options: OptionSelectorOption<T>[];
   selectedValue: T;
   onValueChange: (value: T) => void;
+  layout?: 'vertical' | 'grid';
+  gridColumns?: number;
 }
 
 /**
@@ -21,6 +23,8 @@ type Props<T> = {
  * @param options - 選択肢の配列（value, label, description, 任意のicon）
  * @param selectedValue - 現在選択されている値
  * @param onValueChange - 選択値変更時のコールバック関数
+ * @param layout - 表示レイアウト（vertical: 縦並び、grid: グリッド表示）
+ * @param gridColumns - グリッド表示時の列数（デフォルト: 2）
  * @returns 選択肢コンポーネント
  */
 const OptionSelector = <T,>({
@@ -28,13 +32,23 @@ const OptionSelector = <T,>({
   options,
   selectedValue,
   onValueChange,
+  layout = 'vertical',
+  gridColumns = 2,
 }: Props<T>): JSX.Element => {
   return (
     <div>
       <h2 className="text-lg font-semibold mb-3 text-gray-700">
         {title}
       </h2>
-      <div className="space-y-3">
+      <div className={layout === 'grid' 
+        ? `grid gap-3 ${
+            gridColumns === 2 ? 'grid-cols-1 sm:grid-cols-2' :
+            gridColumns === 3 ? 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3' :
+            gridColumns === 4 ? 'grid-cols-2 md:grid-cols-4' :
+            'grid-cols-2'
+          }` 
+        : 'space-y-3'
+      }>
         {options.map((option, index) => (
           <div
             key={typeof option.value === 'object' ? `option-${index}` : String(option.value)}
@@ -45,13 +59,19 @@ const OptionSelector = <T,>({
                 : 'border-gray-300 bg-gray-50 hover:border-blue-400 hover:bg-blue-50 hover:shadow-md'
             }`}
           >
-            <div className={option.icon ? "flex items-center space-x-3" : ""}>
+            <div className={
+              layout === 'grid' && option.icon 
+                ? "flex flex-col items-center space-y-2 text-center" 
+                : option.icon 
+                  ? "flex items-center space-x-3" 
+                  : ""
+            }>
               {option.icon}
-              <div>
-                <div className={`font-semibold text-base ${selectedValue === option.value ? 'text-blue-700' : 'text-gray-800'}`}>
+              <div className={layout === 'grid' ? "text-center" : ""}>
+                <div className={`font-semibold ${layout === 'grid' ? 'text-sm' : 'text-base'} ${selectedValue === option.value ? 'text-blue-700' : 'text-gray-800'}`}>
                   {option.label}
                 </div>
-                <div className={`text-sm mt-1 ${selectedValue === option.value ? 'text-blue-600' : 'text-gray-600'}`}>
+                <div className={`${layout === 'grid' ? 'text-xs' : 'text-sm'} mt-1 ${selectedValue === option.value ? 'text-blue-600' : 'text-gray-600'}`}>
                   {option.description}
                 </div>
               </div>

--- a/gomoku-game/src/features/cpu/components/CpuLevelSelector/CpuLevelSelector.tsx
+++ b/gomoku-game/src/features/cpu/components/CpuLevelSelector/CpuLevelSelector.tsx
@@ -22,6 +22,8 @@ const CpuLevelSelector = ({ selectedCpuLevel, onCpuLevelChange }: Props): JSX.El
       options={cpuLevelOptions}
       selectedValue={selectedCpuLevel}
       onValueChange={onCpuLevelChange}
+      layout="grid"
+      gridColumns={3}
     />
   );
 };

--- a/gomoku-game/src/features/game/components/ColorSelector/ColorSelector.tsx
+++ b/gomoku-game/src/features/game/components/ColorSelector/ColorSelector.tsx
@@ -45,6 +45,8 @@ const ColorSelector = ({
       options={colorOptions}
       selectedValue={selectedColor}
       onValueChange={onColorChange}
+      layout="grid"
+      gridColumns={3}
     />
   );
 };


### PR DESCRIPTION
## 概要
メニュー画面のレイアウトを大幅に改善し、縦に長すぎて読みにくい問題を解決しました。

## 変更内容
- **OptionSelectorコンポーネント**: グリッドレイアウトオプションを追加
- **CpuLevelSelector**: 5つの選択肢を3列グリッド表示に変更
- **ColorSelector**: 3つの選択肢を横並び表示に変更
- **レスポンシブ対応**: モバイル・タブレット・デスクトップで最適な表示

## 改善効果
- 画面の縦幅を大幅に短縮
- 一画面で全体を把握可能
- 選択肢の視認性と操作性が向上
- モバイルでのスクロール量が最小限に

## テスト
- デスクトップ表示: CPUレベル3列、色選択3列で表示確認
- モバイル表示: 1-2列表示で適切にレスポンシブ動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)