### PR TITLE
🎨 [Accessibility]: モーダル背景の透明度を調整して盤面視認性を向上

### DIFF
--- a/gomoku-game/src/components/Modal/Modal.stories.tsx
+++ b/gomoku-game/src/components/Modal/Modal.stories.tsx
@@ -108,3 +108,90 @@ export const WithForm: Story = {
     ),
   },
 };
+
+export const GameVictoryWithBackground: Story = {
+  args: {
+    isOpen: true,
+    children: (
+      <div className="text-center">
+        <div className="text-6xl mb-4">🎉</div>
+        <h2 className="text-2xl font-bold mb-2 text-gray-800">
+          おめでとうございます！
+        </h2>
+        <p className="text-lg mb-6 text-gray-600">あなたの勝利です</p>
+        <div className="flex gap-3 justify-center">
+          <button className="px-6 py-3 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600 transition-colors">
+            再戦
+          </button>
+          <button className="px-6 py-3 bg-gray-500 text-white font-semibold rounded-lg hover:bg-gray-600 transition-colors">
+            設定変更
+          </button>
+        </div>
+      </div>
+    ),
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-8">
+        {/* ゲーム盤面のような背景コンテンツ */}
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-3xl font-bold text-center mb-8 text-gray-800">
+            五目並べゲーム
+          </h1>
+          
+          {/* 模擬ゲーム盤面 */}
+          <div className="bg-yellow-100 p-4 rounded-lg shadow-lg mb-6">
+            <div 
+              className="bg-yellow-200 p-2 rounded gap-0"
+              style={{ 
+                display: 'grid', 
+                gridTemplateColumns: 'repeat(15, 1fr)' 
+              }}
+            >
+              {Array.from({ length: 225 }, (_, i) => (
+                <div 
+                  key={i}
+                  className="w-6 h-6 border border-gray-400 flex items-center justify-center text-xs"
+                >
+                  {/* ランダムに石を配置 */}
+                  {Math.random() < 0.1 ? (
+                    <div className={`w-4 h-4 rounded-full ${Math.random() < 0.5 ? 'bg-black' : 'bg-white border border-black'}`} />
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+          
+          {/* ゲーム情報 */}
+          <div className="grid grid-cols-2 gap-6">
+            <div className="bg-white p-4 rounded-lg shadow">
+              <h3 className="font-semibold mb-2">プレイヤー情報</h3>
+              <p>あなた: 黒石</p>
+              <p>CPU: 白石</p>
+            </div>
+            <div className="bg-white p-4 rounded-lg shadow">
+              <h3 className="font-semibold mb-2">ゲーム状況</h3>
+              <p>手数: 23手</p>
+              <p>経過時間: 5分32秒</p>
+            </div>
+          </div>
+          
+          {/* 操作ボタン */}
+          <div className="flex justify-center gap-4 mt-6">
+            <button className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+              やり直し
+            </button>
+            <button className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600">
+              ゲーム終了
+            </button>
+          </div>
+        </div>
+        
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/gomoku-game/src/components/Modal/Modal.tsx
+++ b/gomoku-game/src/components/Modal/Modal.tsx
@@ -10,7 +10,7 @@ type Props = {
  * 汎用モーダルダイアログコンポーネント
  * オーバーレイ、フォーカス管理、ESCキー対応を提供する
  */
-export const Modal = ({ isOpen, onClose, children }: Props): JSX.Element => {
+export const Modal = ({ isOpen, onClose, children }: Props): React.JSX.Element => {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -49,7 +49,7 @@ export const Modal = ({ isOpen, onClose, children }: Props): JSX.Element => {
   return (
     <div
       data-testid="modal-overlay"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/75"
       onClick={handleOverlayClick}
     >
       <div


### PR DESCRIPTION
## Summary
- Modal コンポーネントの背景透明度を50%から75%に調整
- Tailwind CSS v4の新記法（bg-black/75）を採用し、非推奨のbg-opacity-*クラスから移行
- 型エラー修正: JSX.Element -> React.JSX.Element
- ゲーム勝利時のStorybookストーリー追加で透明度効果を確認可能

## Test plan
- [x] Storybookで新しいストーリー「Game Victory With Background」を確認
- [x] モーダル背景の透明度が適切に設定されていることを確認
- [x] 後ろのゲーム盤面がモーダル表示時に見えることを確認
- [x] モーダルの視認性が保たれていることを確認
- [x] 型エラーが解消されていることを確認
- [x] Lintチェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)