### PR TITLE
🎨 [Accessibility]: ゲーム画面レイアウトをコンパクトに改善

### DIFF
--- a/gomoku-game/src/features/game/components/GameBoard/GameBoard.tsx
+++ b/gomoku-game/src/features/game/components/GameBoard/GameBoard.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import Stone from "@/components/Stone/Stone";
 import Button from "@/components/elements/Button/Button";
-import TurnIndicator from "@/features/game/components/TurnIndicator/TurnIndicator";
 import Board from "@/features/board/components/Board/Board";
 import { GameResult } from "@/features/game/components/GameResult/GameResult";
+import { PlayerIndicator } from "@/features/game/components/PlayerIndicator/PlayerIndicator";
 import { useGomokuGame, GameSettings } from "@/features/game/hooks/useGomokuGame";
 import { StoneColor } from "@/features/board/utils/stone";
 import { CpuLevel } from "@/features/cpu/utils/cpuLevel";
@@ -26,7 +25,7 @@ interface Props {
  */
 const GameBoard = ({ cpuLevel, playerColor, onBackToStart }: Props): JSX.Element => {
   const gameSettings: GameSettings = { playerColor, cpuLevel };
-  const { board, winner, canMakeMove, makeMove, resetGame, winningLine, showResultModal } = useGomokuGame(gameSettings);
+  const { board, winner, canMakeMove, makeMove, resetGame, winningLine, showResultModal, currentPlayer } = useGomokuGame(gameSettings);
   
   const cpuLevelLabels = {
     beginner: "入門",
@@ -46,8 +45,10 @@ const GameBoard = ({ cpuLevel, playerColor, onBackToStart }: Props): JSX.Element
     onBackToStart();
   };
 
+  const cpuColor: StoneColor = playerColor === "black" ? "white" : "black";
+
   return (
-    <div className="min-h-screen flex flex-col items-center p-4 bg-gray-50">
+    <div className="flex flex-col items-center p-4 bg-gray-50">
       <div className="w-full max-w-4xl">
         <div className="flex justify-between items-center mb-6">
           <Button
@@ -62,11 +63,6 @@ const GameBoard = ({ cpuLevel, playerColor, onBackToStart }: Props): JSX.Element
             <h1 className="text-2xl font-bold text-gray-800 mb-2">五目並べ</h1>
             <div className="flex items-center justify-center space-x-4 text-sm text-gray-600">
               <span>CPUレベル: {cpuLevelLabels[cpuLevel]}</span>
-              <span>|</span>
-              <div className="flex items-center space-x-1">
-                <span>あなた:</span>
-                <Stone color={playerColor} />
-              </div>
             </div>
           </div>
           
@@ -86,14 +82,35 @@ const GameBoard = ({ cpuLevel, playerColor, onBackToStart }: Props): JSX.Element
           </div>
         )}
 
-        <div className="bg-white rounded-lg shadow-lg p-6">
+        <div className="bg-white rounded-lg shadow-lg p-6 relative">
           <div className="text-center mb-4">
             <p className="text-lg text-gray-700">ゲームボード（15×15）</p>
           </div>
           
-          <Board board={board} canMakeMove={canMakeMove} onMakeMove={makeMove} winningLine={winningLine} />
+          <div className="flex items-center justify-center gap-8">
+            {/* プレイヤー石表示（盤面左側） */}
+            <div className="flex items-end h-96">
+              <PlayerIndicator 
+                color={playerColor} 
+                label="あなた" 
+                isCurrentTurn={currentPlayer === playerColor}
+              />
+            </div>
 
-          <TurnIndicator playerColor={playerColor} />
+            {/* ゲームボード */}
+            <div className="relative">
+              <Board board={board} canMakeMove={canMakeMove} onMakeMove={makeMove} winningLine={winningLine} />
+            </div>
+
+            {/* CPU石表示（盤面右側） */}
+            <div className="flex items-start h-96">
+              <PlayerIndicator 
+                color={cpuColor} 
+                label="CPU" 
+                isCurrentTurn={currentPlayer === cpuColor}
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/gomoku-game/src/features/game/components/PlayerIndicator/PlayerIndicator.test.tsx
+++ b/gomoku-game/src/features/game/components/PlayerIndicator/PlayerIndicator.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { PlayerIndicator } from './PlayerIndicator';
+
+describe('PlayerIndicator', () => {
+  test('プレイヤーの石の色と名前を表示する', () => {
+    render(<PlayerIndicator color="black" label="プレイヤー" />);
+
+    expect(screen.getByText('プレイヤー')).toBeInTheDocument();
+    expect(screen.getByTestId('player-stone')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /black stone/i })).toBeInTheDocument();
+  });
+
+  test('CPUの石の色と名前を表示する', () => {
+    render(<PlayerIndicator color="white" label="CPU" />);
+
+    expect(screen.getByText('CPU')).toBeInTheDocument();
+    expect(screen.getByTestId('player-stone')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /white stone/i })).toBeInTheDocument();
+  });
+
+  test('石の色がnoneの場合は空の石を表示する', () => {
+    render(<PlayerIndicator color="none" label="待機中" />);
+
+    expect(screen.getByText('待機中')).toBeInTheDocument();
+    expect(screen.getByTestId('player-stone')).toBeInTheDocument();
+    
+    const stoneElement = screen.getByTestId('player-stone').querySelector('.stone-empty');
+    expect(stoneElement).toBeInTheDocument();
+  });
+
+  test('現在のターンの場合はハイライト表示される', () => {
+    const { container } = render(<PlayerIndicator color="black" label="プレイヤー" isCurrentTurn={true} />);
+
+    const indicator = container.firstChild as HTMLElement;
+    expect(indicator).toHaveClass('border-blue-500', 'bg-blue-50');
+  });
+
+  test('現在のターンでない場合は通常表示される', () => {
+    const { container } = render(<PlayerIndicator color="black" label="プレイヤー" isCurrentTurn={false} />);
+
+    const indicator = container.firstChild as HTMLElement;
+    expect(indicator).toHaveClass('border-gray-300', 'bg-white');
+  });
+});

--- a/gomoku-game/src/features/game/components/PlayerIndicator/PlayerIndicator.tsx
+++ b/gomoku-game/src/features/game/components/PlayerIndicator/PlayerIndicator.tsx
@@ -1,0 +1,28 @@
+import { JSX } from "react";
+import { StoneColor } from "@/features/board/utils/stone";
+import Stone from "@/components/Stone/Stone";
+
+interface PlayerIndicatorProps {
+  color: StoneColor;
+  label: string;
+  isCurrentTurn?: boolean;
+}
+
+export const PlayerIndicator = ({ color, label, isCurrentTurn = false }: PlayerIndicatorProps): JSX.Element => {
+  const borderClass = isCurrentTurn 
+    ? "border-2 border-blue-500 bg-blue-50" 
+    : "border-2 border-gray-300 bg-white";
+  
+  const shadowClass = isCurrentTurn 
+    ? "shadow-lg shadow-blue-200" 
+    : "shadow-md";
+
+  return (
+    <div className={`flex flex-col items-center justify-center gap-2 p-4 rounded-lg w-24 h-28 ${borderClass} ${shadowClass}`}>
+      <div data-testid="player-stone" className="transform scale-150">
+        <Stone color={color} />
+      </div>
+      <span className="text-base font-semibold text-gray-800 text-center">{label}</span>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- ゲーム画面の高さを最適化し、石の色表示をより直感的に改善
- 新しいPlayerIndicatorコンポーネントでターン表示を強化
- レスポンシブ対応とアクセシビリティの向上

## 主な変更内容
### PlayerIndicatorコンポーネント
- 石の色とラベルを表示する新しいコンポーネントを追加
- 現在のターンプレイヤーを青いハイライトで表示
- 統一された固定サイズ（w-24 h-28）で視覚的な一貫性を確保
- 石を1.5倍に拡大して視認性を向上

### ゲーム画面レイアウト改善
- `min-h-screen` を削除して画面高さを最適化
- 盤面の左下に「あなた」、右上に「CPU」の石表示を配置
- 従来のTurnIndicatorを削除し、PlayerIndicatorのハイライトでターン表示
- 白いパネル内に収まるレスポンシブレイアウトに変更

## Test plan
- [x] PlayerIndicatorコンポーネントのユニットテスト（5件）
- [x] GameBoardコンポーネントの統合テスト
- [x] 全テストの実行確認（320件すべてパス）
- [x] ビルドの成功確認
- [x] Storybookでの表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)
