### PR TITLE
🎨 [Accessibility]: 戻るボタンをアイコン化してユーザビリティを向上

### DIFF
--- a/gomoku-game/src/components/elements/BackIcon/BackIcon.stories.tsx
+++ b/gomoku-game/src/components/elements/BackIcon/BackIcon.stories.tsx
@@ -1,0 +1,194 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import BackIcon from "./BackIcon";
+import Button from "../Button/Button";
+
+const meta = {
+  component: BackIcon,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof BackIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "デフォルトの戻るアイコン。mediumサイズで表示されます。",
+      },
+    },
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "small",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "小さなサイズの戻るアイコン。コンパクトなUIに適しています。",
+      },
+    },
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: "medium",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "標準サイズの戻るアイコン。デフォルトサイズです。",
+      },
+    },
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: "large",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "大きなサイズの戻るアイコン。重要な戻るボタンに使用します。",
+      },
+    },
+  },
+};
+
+export const SizeComparison: Story = {
+  render: () => (
+    <div className="flex items-center space-x-8">
+      <div className="text-center">
+        <BackIcon size="small" />
+        <p className="mt-2 text-sm text-gray-600">Small</p>
+      </div>
+      <div className="text-center">
+        <BackIcon size="medium" />
+        <p className="mt-2 text-sm text-gray-600">Medium</p>
+      </div>
+      <div className="text-center">
+        <BackIcon size="large" />
+        <p className="mt-2 text-sm text-gray-600">Large</p>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "3つのサイズの比較表示。用途に応じて適切なサイズを選択できます。",
+      },
+    },
+  },
+};
+
+export const WithCustomStyling: Story = {
+  args: {
+    size: "medium",
+    className: "text-blue-600 hover:text-blue-800 cursor-pointer transition-colors",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "カスタムスタイリングを適用した戻るアイコン。色やホバー効果をカスタマイズできます。",
+      },
+    },
+  },
+};
+
+export const InButtonContext: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h4 className="mb-2 text-sm font-medium text-gray-700">アイコンのみボタン</h4>
+        <Button
+          variant="secondary"
+          icon={<BackIcon />}
+          iconOnly
+          aria-label="戻る"
+        >
+          戻る
+        </Button>
+      </div>
+      <div className="text-center">
+        <h4 className="mb-2 text-sm font-medium text-gray-700">アイコン付きボタン</h4>
+        <Button
+          variant="secondary"
+          icon={<BackIcon />}
+        >
+          戻る
+        </Button>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Buttonコンポーネントと組み合わせた使用例。アイコンのみとテキスト付きの両方のパターン。",
+      },
+    },
+  },
+};
+
+export const GameUIExample: Story = {
+  render: () => (
+    <div className="w-96 p-6 bg-gray-50 rounded-lg">
+      <div className="flex justify-between items-center mb-6">
+        <Button
+          variant="secondary"
+          icon={<BackIcon />}
+          iconOnly
+          aria-label="スタート画面に戻る"
+        >
+          スタート画面に戻る
+        </Button>
+        <h1 className="text-xl font-bold text-gray-800">五目並べ</h1>
+        <div className="w-10"></div>
+      </div>
+      <div className="bg-white p-4 rounded-lg shadow-sm">
+        <p className="text-center text-gray-600">ゲーム画面</p>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "実際のゲームUIでの使用例。ゲーム画面のヘッダー部分で戻るボタンとして使用。",
+      },
+    },
+  },
+};
+
+export const AccessibilityExample: Story = {
+  render: () => (
+    <div className="space-y-4 p-4 bg-white rounded-lg border">
+      <h4 className="font-medium text-gray-800">アクセシビリティ対応</h4>
+      <div className="space-y-2">
+        <p className="text-sm text-gray-600">
+          BackIconは適切なaria-labelを自動的に設定します：
+        </p>
+        <div className="bg-gray-100 p-3 rounded font-mono text-sm">
+          &lt;span aria-label="戻る"&gt;&amp;lt;&lt;/span&gt;
+        </div>
+        <p className="text-sm text-gray-600">
+          スクリーンリーダーで「戻る」として読み上げられます。
+        </p>
+      </div>
+      <BackIcon />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "アクセシビリティの対応例。スクリーンリーダーに対応した適切なaria-labelが設定されています。",
+      },
+    },
+  },
+};

--- a/gomoku-game/src/components/elements/BackIcon/BackIcon.test.tsx
+++ b/gomoku-game/src/components/elements/BackIcon/BackIcon.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import BackIcon from "./BackIcon";
+
+describe("BackIcon", () => {
+  describe("基本的な表示", () => {
+    it("戻るアイコンが表示される", () => {
+      render(<BackIcon />);
+      expect(screen.getByText("<")).toBeInTheDocument();
+    });
+
+    it("適切なaria-labelが設定される", () => {
+      render(<BackIcon />);
+      const icon = screen.getByText("<");
+      expect(icon).toHaveAttribute("aria-label", "戻る");
+    });
+
+    it("デフォルトでmediumサイズが適用される", () => {
+      render(<BackIcon />);
+      const icon = screen.getByText("<");
+      expect(icon).toHaveClass("text-lg");
+    });
+  });
+
+  describe("サイズバリエーション", () => {
+    it("smallサイズが正しく適用される", () => {
+      render(<BackIcon size="small" />);
+      const icon = screen.getByText("<");
+      expect(icon).toHaveClass("text-sm");
+    });
+
+    it("mediumサイズが正しく適用される", () => {
+      render(<BackIcon size="medium" />);
+      const icon = screen.getByText("<");
+      expect(icon).toHaveClass("text-lg");
+    });
+
+    it("largeサイズが正しく適用される", () => {
+      render(<BackIcon size="large" />);
+      const icon = screen.getByText("<");
+      expect(icon).toHaveClass("text-xl");
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    it("セマンティックロール要素として認識される", () => {
+      render(<BackIcon />);
+      const icon = screen.getByText("<");
+      expect(icon).toBeInTheDocument();
+    });
+  });
+});

--- a/gomoku-game/src/components/elements/BackIcon/BackIcon.tsx
+++ b/gomoku-game/src/components/elements/BackIcon/BackIcon.tsx
@@ -1,0 +1,42 @@
+import { JSX } from "react";
+
+type BackIconSize = "small" | "medium" | "large";
+
+type Props = {
+  size?: BackIconSize;
+  className?: string;
+};
+
+/**
+ * 戻るアイコンコンポーネント
+ * 
+ * @param size - アイコンのサイズ（small, medium, large）
+ * @param className - 追加のCSSクラス
+ * @returns 戻るアイコンコンポーネント
+ */
+const BackIcon = ({ size = "medium", className = "" }: Props): JSX.Element => {
+  const sizeClasses = {
+    small: "text-sm",
+    medium: "text-lg",
+    large: "text-xl",
+  };
+
+  const combinedClasses = [
+    "inline-flex items-center justify-center",
+    sizeClasses[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span 
+      className={combinedClasses}
+      aria-label="戻る"
+    >
+      &lt;
+    </span>
+  );
+};
+
+export default BackIcon;

--- a/gomoku-game/src/components/elements/Button/Button.test.tsx
+++ b/gomoku-game/src/components/elements/Button/Button.test.tsx
@@ -156,4 +156,30 @@ describe("Button", () => {
       expect(button).toHaveAttribute("aria-label", "閉じる");
     });
   });
+
+  describe("アイコンサポート", () => {
+    it("アイコンが表示される", () => {
+      const icon = <span data-testid="test-icon">←</span>;
+      render(<Button icon={icon}>戻る</Button>);
+      
+      expect(screen.getByTestId("test-icon")).toBeInTheDocument();
+      expect(screen.getByText("戻る")).toBeInTheDocument();
+    });
+
+    it("アイコンのみモードでテキストが表示されない", () => {
+      const icon = <span data-testid="test-icon">←</span>;
+      render(<Button icon={icon} iconOnly aria-label="戻る">戻る</Button>);
+      
+      expect(screen.getByTestId("test-icon")).toBeInTheDocument();
+      expect(screen.queryByText("戻る")).not.toBeInTheDocument();
+    });
+
+    it("iconOnlyモードでaria-labelが必須", () => {
+      const icon = <span data-testid="test-icon">←</span>;
+      render(<Button icon={icon} iconOnly aria-label="戻る">戻る</Button>);
+      
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-label", "戻る");
+    });
+  });
 });

--- a/gomoku-game/src/components/elements/Button/Button.tsx
+++ b/gomoku-game/src/components/elements/Button/Button.tsx
@@ -7,7 +7,9 @@ type Props = {
   variant?: ButtonVariant;
   size?: ButtonSize;
   fullWidth?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
+  icon?: React.ReactNode;
+  iconOnly?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement>
 
 /**
@@ -17,6 +19,8 @@ type Props = {
  * @param size - ボタンのサイズ（small, medium, large）
  * @param fullWidth - 幅を100%にするかどうか
  * @param children - ボタン内に表示するコンテンツ
+ * @param icon - 表示するアイコン
+ * @param iconOnly - アイコンのみ表示するかどうか
  * @param className - 追加のCSSクラス
  * @param props - その他のHTMLButtonElement属性
  * @returns ボタンコンポーネント
@@ -26,6 +30,8 @@ const Button = ({
   size = "medium",
   fullWidth = false,
   children,
+  icon,
+  iconOnly = false,
   className = "",
   ...props
 }: Props): JSX.Element => {
@@ -56,7 +62,8 @@ const Button = ({
 
   return (
     <button className={combinedClasses} {...props}>
-      {children}
+      {icon && icon}
+      {!iconOnly && children}
     </button>
   );
 };

--- a/gomoku-game/src/features/cpu/utils/analysis/gameStrategy.ts
+++ b/gomoku-game/src/features/cpu/utils/analysis/gameStrategy.ts
@@ -3,18 +3,34 @@ import { Position } from "@/features/board/utils/position";
 import { StoneColor } from "@/features/board/utils/stone";
 import { BOARD_SIZE } from "@/features/board/constants/dimensions";
 
-type GamePhase = 'early' | 'mid' | 'late';
+type GamePhase = "early" | "mid" | "late";
 
 // 戦略的位置（中央からのオフセット）
 const STRATEGIC_POSITIONS = [
-  { row: 0, col: 0 }, { row: 0, col: 1 }, { row: 1, col: 0 }, { row: 1, col: 1 },
-  { row: -1, col: -1 }, { row: -1, col: 0 }, { row: -1, col: 1 },
-  { row: 0, col: -1 }, { row: 0, col: 1 },
-  { row: 1, col: -1 }, { row: 1, col: 0 }, { row: 1, col: 1 },
-  { row: -2, col: -1 }, { row: -2, col: 0 }, { row: -2, col: 1 },
-  { row: -1, col: -2 }, { row: 0, col: -2 }, { row: 1, col: -2 },
-  { row: 2, col: -1 }, { row: 2, col: 0 }, { row: 2, col: 1 },
-  { row: -1, col: 2 }, { row: 0, col: 2 }, { row: 1, col: 2 },
+  { row: 0, col: 0 },
+  { row: 0, col: 1 },
+  { row: 1, col: 0 },
+  { row: 1, col: 1 },
+  { row: -1, col: -1 },
+  { row: -1, col: 0 },
+  { row: -1, col: 1 },
+  { row: 0, col: -1 },
+  { row: 0, col: 1 },
+  { row: 1, col: -1 },
+  { row: 1, col: 0 },
+  { row: 1, col: 1 },
+  { row: -2, col: -1 },
+  { row: -2, col: 0 },
+  { row: -2, col: 1 },
+  { row: -1, col: -2 },
+  { row: 0, col: -2 },
+  { row: 1, col: -2 },
+  { row: 2, col: -1 },
+  { row: 2, col: 0 },
+  { row: 2, col: 1 },
+  { row: -1, col: 2 },
+  { row: 0, col: 2 },
+  { row: 1, col: 2 },
 ] as const;
 
 /**
@@ -29,15 +45,15 @@ export const getOpeningMove = (
   moveHistory: Position[],
   gamePhase: GamePhase
 ): Position | null => {
-  if (gamePhase !== 'early') {
+  if (gamePhase !== "early") {
     return null;
   }
-  
+
   // 初手時：中央付近配置
   if (Board.isEmpty(board)) {
     const centerPosition = Board.getCenterPosition();
     const centerNearbyPositions = Board.getNearbyPositions(centerPosition, 2);
-    
+
     // 中央に最も近い位置を優先
     for (const position of centerNearbyPositions) {
       if (StoneColor.isNone(board[position.row][position.col])) {
@@ -45,15 +61,15 @@ export const getOpeningMove = (
       }
     }
   }
-  
+
   // 2手目以降は戦略的要所
   const center = Math.floor(BOARD_SIZE / 2);
   for (const offset of STRATEGIC_POSITIONS) {
-    const position = { 
-      row: center + offset.row, 
-      col: center + offset.col 
+    const position = {
+      row: center + offset.row,
+      col: center + offset.col,
     };
-    
+
     if (
       Board.isValidPosition(position.row, position.col) &&
       StoneColor.isNone(board[position.row][position.col])
@@ -61,6 +77,6 @@ export const getOpeningMove = (
       return position;
     }
   }
-  
+
   return null;
 };

--- a/gomoku-game/src/features/game/components/GameBoard/GameBoard.tsx
+++ b/gomoku-game/src/features/game/components/GameBoard/GameBoard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Button from "@/components/elements/Button/Button";
+import BackIcon from "@/components/elements/BackIcon/BackIcon";
 import Board from "@/features/board/components/Board/Board";
 import { GameResult } from "@/features/game/components/GameResult/GameResult";
 import { PlayerIndicator } from "@/features/game/components/PlayerIndicator/PlayerIndicator";
@@ -55,6 +56,9 @@ const GameBoard = ({ cpuLevel, playerColor, onBackToStart }: Props): JSX.Element
             onClick={onBackToStart}
             variant="secondary"
             size="medium"
+            icon={<BackIcon />}
+            iconOnly
+            aria-label="スタート画面に戻る"
           >
             スタート画面に戻る
           </Button>

--- a/gomoku-game/src/features/game/components/GameResult/GameResult.test.tsx
+++ b/gomoku-game/src/features/game/components/GameResult/GameResult.test.tsx
@@ -73,7 +73,7 @@ describe("GameResult", () => {
     
     render(<GameResult {...props} />);
     
-    const backToMenuButton = screen.getByText("設定変更");
+    const backToMenuButton = screen.getByLabelText("設定変更");
     await user.click(backToMenuButton);
     
     expect(onBackToMenu).toHaveBeenCalledTimes(1);

--- a/gomoku-game/src/features/game/components/GameResult/GameResult.tsx
+++ b/gomoku-game/src/features/game/components/GameResult/GameResult.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import Button from "@/components/elements/Button/Button";
+import BackIcon from "@/components/elements/BackIcon/BackIcon";
 import { StoneColor } from "@/features/board/utils/stone";
 
 interface Props {
@@ -49,18 +51,23 @@ export const GameResult = ({ showResult, winner, playerColor, onRestart, onBackT
         </div>
         
         <div className="flex gap-3">
-          <button
+          <Button
             onClick={onRestart}
-            className="px-6 py-3 bg-white text-blue-600 font-bold rounded-lg hover:bg-blue-50 transition-colors shadow-md"
+            variant="primary"
+            className="bg-white text-blue-600 hover:bg-blue-50 shadow-md"
           >
             再戦
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={onBackToMenu}
-            className="px-6 py-3 bg-white text-purple-600 font-bold rounded-lg hover:bg-gray-100 transition-colors shadow-md"
+            variant="secondary"
+            icon={<BackIcon />}
+            iconOnly
+            aria-label="設定変更"
+            className="bg-white text-purple-600 hover:bg-gray-100 shadow-md"
           >
             設定変更
-          </button>
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要

ゲーム画面の戻るボタンを文字ベースから「<」アイコンに変更し、よりモダンで直感的なUIに改善しました。

## 変更内容

### 🆕 新規コンポーネント
- **BackIconコンポーネント**：「<」記号による戻るアイコン
  - small/medium/largeサイズバリエーション対応
  - aria-label自動設定でアクセシビリティ対応
  - Storybookファイルも同時作成

### 🔧 既存コンポーネント拡張
- **Buttonコンポーネント**：アイコンサポート機能追加
  - `icon`、`iconOnly`、`aria-label`プロパティ追加
  - アイコンのみ表示モードを実装

### 🎨 UI改善
- **ゲーム画面**：「スタート画面に戻る」→「<」アイコンに変更
- **ゲーム結果画面**：「設定変更」→「<」アイコンに変更
- コンパクトで現代的なUI実現

## 技術的特徴

- **TDD（テスト駆動開発）**：Red → Green → Refactorサイクルで実装
- **アクセシビリティ対応**：aria-labelによるスクリーンリーダー対応
- **型安全性**：TypeScriptによる厳密な型定義
- **再利用性**：BackIconコンポーネントは汎用的に利用可能

## テスト対応

- BackIconコンポーネント：7つのテストケース
- Buttonコンポーネント：アイコンサポート用テスト3つ追加
- 既存テスト：アイコン化に伴う修正対応

## スクリーンショット

- ゲーム画面：戻るボタンが「<」アイコンでコンパクトに表示
- ゲーム結果画面：設定変更ボタンも「<」アイコンに統一

## 破壊的変更

なし（既存APIは完全に互換性維持）

🤖 Generated with [Claude Code](https://claude.ai/code)