### PR TITLE
🐛 [Bug fix]: Lintエラーの修正

### DIFF
--- a/gomoku-game/src/components/elements/BackIcon/BackIcon.stories.tsx
+++ b/gomoku-game/src/components/elements/BackIcon/BackIcon.stories.tsx
@@ -175,7 +175,7 @@ export const AccessibilityExample: Story = {
           BackIconは適切なaria-labelを自動的に設定します：
         </p>
         <div className="bg-gray-100 p-3 rounded font-mono text-sm">
-          &lt;span aria-label="戻る"&gt;&amp;lt;&lt;/span&gt;
+          &lt;span aria-label=&quot;戻る&quot;&gt;&amp;lt;&lt;/span&gt;
         </div>
         <p className="text-sm text-gray-600">
           スクリーンリーダーで「戻る」として読み上げられます。

--- a/gomoku-game/src/features/game/components/GameResult/GameResult.test.tsx
+++ b/gomoku-game/src/features/game/components/GameResult/GameResult.test.tsx
@@ -73,7 +73,7 @@ describe("GameResult", () => {
     
     render(<GameResult {...props} />);
     
-    const backToMenuButton = screen.getByLabelText("設定変更");
+    const backToMenuButton = screen.getByText("設定に戻る");
     await user.click(backToMenuButton);
     
     expect(onBackToMenu).toHaveBeenCalledTimes(1);

--- a/gomoku-game/src/features/game/components/GameResult/GameResult.tsx
+++ b/gomoku-game/src/features/game/components/GameResult/GameResult.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Button from "@/components/elements/Button/Button";
-import BackIcon from "@/components/elements/BackIcon/BackIcon";
 import { StoneColor } from "@/features/board/utils/stone";
 
 interface Props {


### PR DESCRIPTION
## 概要
- BackIcon.stories.tsxのエスケープされていない引用符を修正
- GameResult.tsxの未使用インポートを削除  
- GameResult.test.tsxのテストセレクタを修正

## 修正内容
### 1. BackIcon.stories.tsx
- React Lintエラーの解消のため、aria-label属性の引用符を`&quot;`でエスケープ

### 2. GameResult.tsx
- ESLintエラーの解消のため、未使用のBackIconインポートを削除

### 3. GameResult.test.tsx
- BackIconインポート削除に伴い、`getByLabelText("設定変更")`を`getByText("設定に戻る")`に変更

## テスト計画
- [x] Lintエラーが解消されていることを確認
- [x] 全てのテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)